### PR TITLE
Sort Trade Paperback to own folder

### DIFF
--- a/metrontagger/filesorter.py
+++ b/metrontagger/filesorter.py
@@ -52,7 +52,13 @@ class FileSorter:
         publisher, series, volume = self._cleanup_metadata(meta_data)
 
         if publisher and series and volume:
-            new_path = pathlib.Path(self.sort_directory) / publisher / series / f"v{volume}"
+            tpb = meta_data.series.format == "Trade Paperback"
+            new_path = (
+                pathlib.Path(self.sort_directory)
+                / publisher
+                / f"{f'{series} TPB' if tpb else f'{series}'}"
+                / f"v{volume}"
+            )
         else:
             questionary.print(
                 "Missing metadata from comic and will be unable to sort."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,20 @@ def talker() -> Talker:
 
 
 @pytest.fixture(scope="function")
+def fake_tpb_metadata() -> GenericMetadata:
+    meta_data = GenericMetadata()
+    meta_data.publisher = "DC Comics"
+    meta_data.series = SeriesMetadata("Batman", volume=1, format="Trade Paperback")
+    meta_data.issue = "1"
+    meta_data.cover_date = date(2021, 9, 1)
+    meta_data.add_credit("Grant Morrison", "Writer")
+    meta_data.add_credit("Chris Burham", "Artist")
+    meta_data.add_credit("Chris Burham", "Cover")
+
+    return meta_data
+
+
+@pytest.fixture(scope="function")
 def fake_metadata() -> GenericMetadata:
     meta_data = GenericMetadata()
     meta_data.publisher = "DC Comics"

--- a/tests/test_filesorter.py
+++ b/tests/test_filesorter.py
@@ -54,6 +54,33 @@ def test_sort_comic(
     assert res is True
 
 
+@pytest.mark.skipif(sys.platform in ["win32"], reason="Skip Windows.")
+def test_sort_tpb(
+    fake_comic: ZipFile, fake_tpb_metadata: GenericMetadata, tmp_path: Path
+) -> None:
+    test_dir = tmp_path / "sort1"
+
+    test_dir.mkdir()
+
+    result_dir = (
+        test_dir
+        / fake_tpb_metadata.publisher
+        / f"{fake_tpb_metadata.series.name} TPB"
+        / f"v{fake_tpb_metadata.series.volume}"
+    )
+
+    # Write metadata to fake file
+    comic = ComicArchive(fake_comic)
+    if comic.has_metadata():
+        comic.remove_metadata()
+    comic.write_metadata(fake_tpb_metadata)
+
+    file_sorter = FileSorter(test_dir)
+    res = file_sorter.sort_comics(fake_comic)
+    assert result_dir.is_dir()
+    assert res is True
+
+
 def test_sort_files_without_metadata(fake_comic: ZipFile, tmp_path: Path) -> None:
     test_dir = tmp_path / "sort2"
     # If we add more tests we should probably create another tmpfile


### PR DESCRIPTION
Sort Trade Paperbacks to own folder to prevent filename collisions.