### PR TITLE
Handle matching of issue #½ better

### DIFF
--- a/metrontagger/filerenamer.py
+++ b/metrontagger/filerenamer.py
@@ -107,12 +107,14 @@ class FileRenamer:
         new_name = self.replace_token(new_name, meta_data.series.name, "%series%")
         new_name = self.replace_token(new_name, meta_data.series.volume, "%volume%")
 
-        if meta_data.issue is not None:
+        if meta_data.issue is None:
+            issue_str = None
+        elif meta_data.issue == "½":
+            issue_str = IssueString("0.5").as_string(pad=self.issue_zero_padding)
+        else:
             issue_str = "{}".format(
                 IssueString(meta_data.issue).as_string(pad=self.issue_zero_padding),
             )
-        else:
-            issue_str = None
         new_name = self.replace_token(new_name, issue_str, "%issue%")
 
         new_name = self.replace_token(new_name, meta_data.issue_count, "%issuecount%")

--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -35,6 +35,9 @@ def create_query_params(filename: Path) -> dict[str, str]:
 
     # If there isn't an issue number, let's assume it's "1".
     number: str = quote_plus(fnp.issue.encode("utf-8")) if fnp.issue else "1"
+    # Handle issues with #½
+    if number == "0.5":
+        number = "½"
 
     params = {
         "series_name": series_string,


### PR DESCRIPTION
Issue on Metron use `½` for numbering, but that doesn't play well with some filesystems, so we'll use `.5` (user pad setting) when we rename the file.