### PR TITLE
Improve handling of series format better

### DIFF
--- a/metrontagger/filerenamer.py
+++ b/metrontagger/filerenamer.py
@@ -159,7 +159,10 @@ class FileRenamer:
         )
         new_name = self.replace_token(new_name, meta_data.alternate_count, "%alternatecount%")
         new_name = self.replace_token(new_name, meta_data.imprint, "%imprint%")
-        new_name = self.replace_token(new_name, meta_data.series.format, "%format%")
+        if meta_data.series.format == "Hard Cover":
+            new_name = self.replace_token(new_name, "HC", "%format%")
+        elif meta_data.series.format == "Trade Paperback":
+            new_name = self.replace_token(new_name, "TPB", "%format%")
         new_name = self.replace_token(new_name, meta_data.age_rating, "%maturityrating%")
         new_name = self.replace_token(new_name, meta_data.stories, "%storyarc%")
         new_name = self.replace_token(new_name, meta_data.series_group, "%seriesgroup%")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,3 +72,17 @@ def fake_comic(tmp_path_factory: Path) -> zipfile.ZipFile:
         zf.writestr("cover.jpg", image_data)
 
     return z_file
+
+
+@pytest.fixture()
+def fake_tpb(tmp_path_factory: Path) -> zipfile.ZipFile:
+    z_file = (
+        tmp_path_factory.mktemp("comic")
+        / "Batman - The Adventures Continue Season One (2021) "
+        "(digital) (Son of Ultron-Empire).cbz"
+    )
+    image_data = create_cover_page()
+    with zipfile.ZipFile(z_file, mode="w") as zf:
+        zf.writestr("cover.jpg", image_data)
+
+    return z_file

--- a/tests/test_filerenamer.py
+++ b/tests/test_filerenamer.py
@@ -33,6 +33,28 @@ def test_rename_file(fake_comic: ZipFile) -> None:
     assert expected_result == renamed_file.name
 
 
+def test_rename_tpb(fake_tpb: ZipFile, fake_tpb_metadata: Metadata) -> None:
+    fn = (
+        "Batman - The Adventures Continue Season One (2021) "
+        "(digital) (Son of Ultron-Empire).cbz"
+    )
+    assert fake_tpb.name == fn
+    renamer = FileRenamer(fake_tpb_metadata)
+    renamer.set_template("%series% %format% v%volume% #%issue% (%year%)")
+    renamer.set_issue_zero_padding(3)
+    renamer.set_smart_cleanup(True)
+    renamed_file = renamer.rename_file(fake_tpb)
+    assert renamed_file is not None
+    expected_result = (
+        f"{fake_tpb_metadata.series.name} "
+        "TPB "
+        f"v{fake_tpb_metadata.series.volume} "
+        f"#00{fake_tpb_metadata.issue} "
+        f"({fake_tpb_metadata.cover_date.year}).cbz"
+    )
+    assert expected_result == renamed_file.name
+
+
 def test_half_issues_rename(fake_comic: ZipFile) -> None:
     md = Metadata()
     md.series = Series("Batman", volume=2)


### PR DESCRIPTION
Use abbreviated words for 'Hard Cover' & 'Trade Paperback', since this is fairly common for file naming.