### PR TITLE
Remove Unused Method

### DIFF
--- a/metrontagger/settings.py
+++ b/metrontagger/settings.py
@@ -5,10 +5,7 @@ from os import environ
 from pathlib import Path, PurePath
 from typing import Optional
 
-import questionary
 from xdg.BaseDirectory import save_config_path
-
-from metrontagger.styles import Styles
 
 
 class MetronTaggerSettings:
@@ -46,9 +43,6 @@ class MetronTaggerSettings:
         if not self.settings_file.parent.exists():
             self.settings_file.parent.mkdir()
 
-        # We can probably remove this in a year or so. Around 2023-06-01
-        self._migrate_old_config()
-
         # Write the config file if it doesn't exist
         if not self.settings_file.exists():
             self.save()
@@ -64,22 +58,6 @@ class MetronTaggerSettings:
 
         windows_path = PurePath(environ["APPDATA"]).joinpath("MetronTagger")
         return Path(windows_path)
-
-    def _migrate_old_config(self: "MetronTaggerSettings") -> None:
-        old_config = Path.home() / ".MetronTagger" / "settings.ini"
-        if old_config.exists():
-            # Let's move any existing config to the new location
-            old_config.replace(self.settings_file)
-            questionary.print(
-                f"Migrated existing configuration to: {self.settings_file.parent}",
-                style=Styles.WARNING,
-            )
-            if old_config.parent.exists():
-                questionary.print(
-                    f"Removing old configuration directory: {old_config.parent}",
-                    style=Styles.WARNING,
-                )
-                old_config.parent.rmdir()
 
     def load(self: "MetronTaggerSettings") -> None:
         """Method to retrieve a users settings"""


### PR DESCRIPTION
Remove migrate_old_config() method. It shouldn't be needed any longer.