### PR TITLE
Improve Matching

### DIFF
--- a/metrontagger/logging.py
+++ b/metrontagger/logging.py
@@ -1,0 +1,18 @@
+"""Logging module"""
+
+import logging
+from logging import basicConfig
+
+from metrontagger.settings import MetronTaggerSettings
+
+DATE_FMT = "%Y-%m-%d %H:%M:%S %Z"
+LOG_FMT = "{asctime} {levelname:8} {message}"
+
+
+def init_logging(config: MetronTaggerSettings) -> None:
+    """Initializing logging"""
+    formatter = logging.Formatter(LOG_FMT, style="{", datefmt=DATE_FMT)
+    log_path = config.get_settings_folder() / "metron-tagger.log"
+    handler = logging.FileHandler(str(log_path))
+    handler.setFormatter(formatter)
+    basicConfig(level=logging.WARNING, handlers=[handler])

--- a/metrontagger/run.py
+++ b/metrontagger/run.py
@@ -8,6 +8,7 @@ from darkseid.utils import get_recursive_filelist
 from metrontagger.duplicates import DuplicateIssue, Duplicates
 from metrontagger.filerenamer import FileRenamer
 from metrontagger.filesorter import FileSorter
+from metrontagger.logging import init_logging
 from metrontagger.settings import MetronTaggerSettings
 from metrontagger.styles import Styles
 from metrontagger.talker import Talker
@@ -285,6 +286,9 @@ class Runner:
         if not (file_list := get_recursive_filelist(self.config.path)):
             questionary.print("No files to process. Exiting.", style=Styles.WARNING)
             exit(0)
+
+        # Start logging
+        init_logging(self.config)
 
         if self.config.missing:
             self._comics_with_no_metadata(file_list)

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -206,12 +206,12 @@ class Talker:
 
         if success and md is not None:
             collection = bool(md.series.format.lower() in ["trade paperback", "hard cover"])
-            questionary.print(
+            msg = (
                 f"Using '{md.series.name} #{md.issue} ({md.cover_date.year})"
                 f'{" (Collection)' " if collection else "' "}'
-                f"metadata for '{filename.name}'.",
-                style=Styles.SUCCESS,
+                f"metadata for '{filename.name}'."
             )
+            questionary.print(msg, style=Styles.SUCCESS)
         else:
             questionary.print(
                 f"There was a problem writing metadata for '{filename.name}'.",

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -208,7 +208,7 @@ class Talker:
             collection = bool(md.series.format.lower() in ["trade paperback", "hard cover"])
             msg = (
                 f"Using '{md.series.name} #{md.issue} ({md.cover_date.year})"
-                f'{" (Collection)' " if collection else "' "}'
+                f"""{" (Collection)' " if collection else "' "}"""
                 f"metadata for '{filename.name}'."
             )
             questionary.print(msg, style=Styles.SUCCESS)

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -208,7 +208,8 @@ class Talker:
             collection = bool(md.series.format.lower() in ["trade paperback", "hard cover"])
             questionary.print(
                 f"Using '{md.series.name} #{md.issue} ({md.cover_date.year})"
-                f"{' (Collection)\'' if collection else '\''} metadata for '{filename.name}'.",
+                f'{" (Collection)' " if collection else "' "}'
+                f"metadata for '{filename.name}'.",
                 style=Styles.SUCCESS,
             )
         else:

--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -1,8 +1,5 @@
 """Some miscellaneous functions"""
-from pathlib import Path
 from urllib.parse import quote_plus
-
-from comicfn2dict import comicfn2dict
 
 
 def cleanup_string(path_name: str | None) -> str | None:
@@ -22,10 +19,7 @@ def cleanup_string(path_name: str | None) -> str | None:
     return path_name.replace("?", "")
 
 
-def create_query_params(filename: Path) -> dict[str, str]:
-    """Function to create a diction of values based on the provided filename"""
-    metadata: dict[str, str | tuple[str, ...]] = comicfn2dict(filename, verbose=0)
-
+def create_query_params(metadata: dict[str, str | tuple[str, ...]]) -> dict[str, str]:
     # TODO: Should probably check if there is a 'series' key.
     # Remove hyphen when searching for series name
     series_string: str = metadata["series"].replace(" - ", " ").strip()
@@ -40,15 +34,7 @@ def create_query_params(filename: Path) -> dict[str, str]:
     if number == ".5":
         number = "½"
 
-    params = {
+    return {
         "series_name": series_string,
         "number": number,
     }
-    # TODO: Probably want to remove these from the API call and use the info instead to find the issue
-    #       from the return results.
-    if "volume" in metadata:
-        params["series_volume"] = metadata["volume"]
-    if "year" in metadata:
-        params["cover_year"] = metadata["year"]
-
-    return params

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,19 +220,19 @@ toml = ["tomli"]
 
 [[package]]
 name = "darkseid"
-version = "3.2.2"
+version = "4.0.0"
 description = "A library to interact with comic archives"
 optional = false
-python-versions = ">=3.9,<4.0"
+python-versions = ">=3.10,<4.0"
 files = [
-    {file = "darkseid-3.2.2-py3-none-any.whl", hash = "sha256:17ea37d560d4cc57a50ed2c76f25152d866b81643eeed083744d2a1e283cb099"},
-    {file = "darkseid-3.2.2.tar.gz", hash = "sha256:85350d76979e9444161b84d9a91774c2b4b73fa30b75c1c441ba785c664ebc14"},
+    {file = "darkseid-4.0.0-py3-none-any.whl", hash = "sha256:3e7df1d6514327bda832d751a485b0da0e8043e780970069362e63339174a213"},
+    {file = "darkseid-4.0.0.tar.gz", hash = "sha256:17150d08771064e6ab52de78931f3771de35b6e5213122c5fff2a9a75d471b49"},
 ]
 
 [package.dependencies]
 natsort = ">=8.0.0,<9.0.0"
 Pillow = ">=10.0.1,<11.0.0"
-pycountry = ">=22.3.5,<23.0.0"
+pycountry = ">=23.12.11,<24.0.0"
 rarfile = ">=4.0,<5.0"
 
 [[package]]
@@ -771,16 +771,14 @@ files = [
 
 [[package]]
 name = "pycountry"
-version = "22.3.5"
+version = "23.12.11"
 description = "ISO country, subdivision, language, currency and script definitions and their translations"
 optional = false
-python-versions = ">=3.6, <4"
+python-versions = ">=3.8"
 files = [
-    {file = "pycountry-22.3.5.tar.gz", hash = "sha256:b2163a246c585894d808f18783e19137cb70a0c18fb36748dc01fc6f109c1646"},
+    {file = "pycountry-23.12.11-py3-none-any.whl", hash = "sha256:2ff91cff4f40ff61086e773d61e72005fe95de4a57bfc765509db05695dc50ab"},
+    {file = "pycountry-23.12.11.tar.gz", hash = "sha256:00569d82eaefbc6a490a311bfa84a9c571cff9ddbf8b0a4f4e7b4f868b4ad925"},
 ]
-
-[package.dependencies]
-setuptools = "*"
 
 [[package]]
 name = "pydantic"
@@ -1048,6 +1046,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1353,4 +1352,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a0c9ba7566b53e53c84204bc24eb6a40972d6599f0487a38031c6d0606abaaf"
+content-hash = "7547e0cab231abf6f328085426e52ce02fea97f98d1eff936535376213e9528d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ keywords = ["comics", "comic", "metadata", "tagging", "tagger"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-mokkari = "^3.0.0"
+mokkari = "^3.0.1"
 questionary = "^2.0.1"
 pyxdg = "^0.28"
-darkseid = "^3.2.2"
+darkseid = "^4.0.0"
 lxml = "^4.9.1"
 imagehash = "^4.3.1"
-pandas = "^2.2.0"
+pandas = "^2.2.1"
 comicfn2dict = "^0.2.0"
 
 [tool.poetry.scripts]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from comicfn2dict import comicfn2dict
 
 from metrontagger.utils import cleanup_string, create_query_params
 
@@ -12,13 +13,12 @@ def test_dict(tmp_path: Path) -> None:
     year = "1999"
     # Make the tmp file
     comic = tmp_path / f"{series} v{volume} #{number} ({year}).cbz"
+    md = comicfn2dict(comic)
 
-    result = create_query_params(comic)
+    result = create_query_params(md)
     expected = {
         "series_name": f"{series}",
-        "series_volume": f"{volume}",
         "number": f"{number}",
-        "cover_year": f"{year}",
     }
     assert result == expected
 
@@ -30,13 +30,12 @@ def test_dict_with_title_hyphon(tmp_path: Path) -> None:
     year = "2013"
     # Make the tmp file
     comic = tmp_path / f"{series} v{volume} #{number} ({year}).cbz"
+    md = comicfn2dict(comic)
 
-    result = create_query_params(comic)
+    result = create_query_params(md)
     expected = {
         "series_name": "Batman Superman",
-        "series_volume": f"{volume}",
         "number": f"{number}",
-        "cover_year": f"{year}",
     }
     assert result == expected
 
@@ -46,12 +45,12 @@ def test_query_dict_without_issue_number(tmp_path: Path) -> None:
     year = "1990"
     # Make the tmp file
     comic = tmp_path / f"{series} ({year}).cbz"
+    md = comicfn2dict(comic)
 
-    result = create_query_params(comic)
+    result = create_query_params(md)
     expected = {
         "series_name": f"{series}",
         "number": "1",
-        "cover_year": f"{year}",
     }
     assert result == expected
 


### PR DESCRIPTION
Instead of passing 'volume' & 'year' params to Metron's issue endpoint, let's return a larger result set.

That way we can compare the issue's cover hash to get the right one. Based on my initial testing this works pretty well, tho older issues with bad cover's may not give that great of results.

If it turns out this doesn't work for most user's, we can look at using the 'volume' and 'year' to narrow down the results.