### PR TITLE
Use existing `ComicInfo.xml` to identify comic

### DIFF
--- a/metrontagger/styles.py
+++ b/metrontagger/styles.py
@@ -3,3 +3,4 @@ class Styles:
     SUCCESS = "fg:ansigreen"
     WARNING = "fg:ansiyellow"
     ERROR = "fg:ansired"
+    INFO = "fg:ansipurple"


### PR DESCRIPTION
If a user's comic was already tagged with information with **ComicTagger** or **Metron-Tagger** we can get either the CVID or Metron ID and use that info to refresh the `ComicInfo.xml` data.

If the comic has a CVID and that info isn't available it will fall back to using the comic filename to search.