### PR TITLE
Strip commas and `&` from series name

### DIFF
--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -22,7 +22,9 @@ def cleanup_string(path_name: str | None) -> str | None:
 def create_query_params(metadata: dict[str, str | tuple[str, ...]]) -> dict[str, str]:
     # TODO: Should probably check if there is a 'series' key.
     # Remove hyphen when searching for series name
-    series_string: str = metadata["series"].replace(" - ", " ").strip()
+    series_string: str = (
+        metadata["series"].replace(" - ", " ").replace(",", "").replace(" & ", " ").strip()
+    )
 
     # If there isn't an issue number, let's assume it's "1".
     number: str = quote_plus(metadata["issue"].encode("utf-8")) if "issue" in metadata else "1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,6 +55,15 @@ def test_query_dict_without_issue_number(tmp_path: Path) -> None:
     assert result == expected
 
 
+def test_query_dict_with_issue_number(tmp_path: Path) -> None:
+    fn = "Moon Knight - Black, White, & Blood #1.cbz"
+    comic = tmp_path / fn
+    md = comicfn2dict(comic)
+    result = create_query_params(md)
+    expected = {"series_name": "Moon Knight Black White Blood", "number": "1"}
+    assert result == expected
+
+
 test_strings = [
     pytest.param("Hashtag: Danger (2019)", "Cleanup colon space", "Hashtag - Danger (2019)"),
     pytest.param("Hashtag :Danger (2019)", "Cleanup space colon", "Hashtag -Danger (2019)"),


### PR DESCRIPTION
Remove commas and `&` from the series name before querying Metron.