### PR TITLE
Fix Tagging Bug with Existing `ComicInfo.xml`

### DIFF
--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -124,6 +124,10 @@ class Talker:
         source: InfoSource = InfoSource.unknown
         id_: int | None = None
 
+        # If `Notes` element doesn't exist let's bail.
+        if md.notes is None:
+            return source, id_
+
         lower_notes = md.notes.lower()
         if "metrontagger" in lower_notes:
             source = InfoSource.metron


### PR DESCRIPTION
If the comic has an existing `ComicInfo.xml` we need to check that the `Notes` element exists.