### PR TITLE
Ignore `Corrupt EXIF data` warnings

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,0 @@
-name: Ruff
-on: [push, pull_request]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.1
+    rev: v0.6.1
     hooks:
       - id: ruff
       - id: ruff-format

--- a/metrontagger/duplicates.py
+++ b/metrontagger/duplicates.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import warnings
 from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
@@ -18,6 +19,10 @@ from tqdm import tqdm
 from metrontagger.styles import Styles
 
 LOGGER = getLogger(__name__)
+
+warnings.filterwarnings(
+    "ignore", category=UserWarning
+)  # Ignore 'UserWarning: Corrupt EXIF data' warnings
 
 
 @dataclass

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import warnings
 from datetime import datetime
 from enum import Enum, auto, unique
 from logging import getLogger
@@ -29,6 +30,11 @@ from metrontagger.styles import Styles
 from metrontagger.utils import create_query_params
 
 LOGGER = getLogger(__name__)
+
+warnings.filterwarnings(
+    "ignore", category=UserWarning
+)  # Ignore 'UserWarning: Corrupt EXIF data' warnings
+
 HAMMING_DISTANCE = 10
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1069,13 +1069,13 @@ testing = ["covdefaults (>=2.3)", "pytest (>=8.2.2)", "pytest-cov (>=5)", "pytes
 
 [[package]]
 name = "pyright"
-version = "1.1.375"
+version = "1.1.376"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.375-py3-none-any.whl", hash = "sha256:4c5e27eddeaee8b41cc3120736a1dda6ae120edf8523bb2446b6073a52f286e3"},
-    {file = "pyright-1.1.375.tar.gz", hash = "sha256:7765557b0d6782b2fadabff455da2014476404c9e9214f49977a4e49dec19a0f"},
+    {file = "pyright-1.1.376-py3-none-any.whl", hash = "sha256:0f2473b12c15c46b3207f0eec224c3cea2bdc07cd45dd4a037687cbbca0fbeff"},
+    {file = "pyright-1.1.376.tar.gz", hash = "sha256:bffd63b197cd0810395bb3245c06b01f95a85ddf6bfa0e5644ed69c841e954dd"},
 ]
 
 [package.dependencies]
@@ -1458,13 +1458,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.17.1"
+version = "4.18.0"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.17.1-py3-none-any.whl", hash = "sha256:2974597c0353577126ab014f52d1a399fb761049e165ff34427f84e8cfe6c990"},
-    {file = "tox-4.17.1.tar.gz", hash = "sha256:2c41565a571e34480bd401d668a4899806169a4633e972ac296c54406d2ded8a"},
+    {file = "tox-4.18.0-py3-none-any.whl", hash = "sha256:0a457400cf70615dc0627eb70d293e80cd95d8ce174bb40ac011011f0c03a249"},
+    {file = "tox-4.18.0.tar.gz", hash = "sha256:5dfa1cab9f146becd6e351333a82f9e0ade374451630ba65ee54584624c27b58"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Don't really care about corrupt EXIF data, so let's ignore the warning.