### PR TITLE
Add --accept-only option to automatically accept single valid matches

### DIFF
--- a/metrontagger/options.py
+++ b/metrontagger/options.py
@@ -64,6 +64,12 @@ def make_parser() -> argparse.ArgumentParser:
         default=False,
     )
     parser.add_argument(
+        "--accept-only",
+        help="Automatically accept the match when exactly one valid match is found.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--missing",
         help="List files without metadata.",
         action="store_true",

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -257,7 +257,9 @@ class Talker:
 
         return src, id_
 
-    def _process_file(self: Talker, fn: Path, interactive: bool, accept_only: bool = False) -> tuple[int | None, bool]:  # noqa: PLR0912 PLR0911 PLR0915
+    def _process_file(  # noqa: PLR0912 PLR0911 PLR0915
+        self: Talker, fn: Path, interactive: bool, accept_only: bool = False
+    ) -> tuple[int | None, bool]:
         """Process a comic file for metadata.
 
         This method processes a comic file to extract metadata, including checking for existing metadata, extracting
@@ -385,7 +387,7 @@ class Talker:
         if accept_only:
             self.match_results.add_good_match(fn)
             return i_list[0].id, False
-        
+
         # Otherwise, add to multiple matches to ask the user later
         self.match_results.add_multiple_match(MultipleMatch(fn, i_list))
         return None, True
@@ -521,7 +523,9 @@ class Talker:
                     )
                     continue
 
-            issue_id, multiple_match = self._process_file(fn, args.interactive, args.accept_only)
+            issue_id, multiple_match = self._process_file(
+                fn, args.interactive, args.accept_only
+            )
             if issue_id:
                 self._write_issue_md(fn, issue_id)
             elif not multiple_match:

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -257,7 +257,7 @@ class Talker:
 
         return src, id_
 
-    def _process_file(self: Talker, fn: Path, interactive: bool) -> tuple[int | None, bool]:  # noqa: PLR0912 PLR0911 PLR0915
+    def _process_file(self: Talker, fn: Path, interactive: bool, accept_only: bool = False) -> tuple[int | None, bool]:  # noqa: PLR0912 PLR0911 PLR0915
         """Process a comic file for metadata.
 
         This method processes a comic file to extract metadata, including checking for existing metadata, extracting
@@ -266,7 +266,7 @@ class Talker:
         Args:
             fn: Path: The file path of the comic to process.
             interactive: bool: A flag indicating if the process should be interactive.
-
+            accept_only: bool: A flag indicating if the process should automatically accept a match if it's the only one.
         Returns: tuple[int | None, bool]: A tuple containing the issue ID and a flag indicating if multiple matches
         were found.
         """
@@ -380,7 +380,13 @@ class Talker:
             self.match_results.add_good_match(fn)
             return i_list[0].id, False
 
-        # Single match not withing the hamming distance. We'll ask if the single choice is correct.
+        # Single match not within the hamming distance.
+        # If --accept-only flag is set and there's exactly one match, automatically accept it
+        if accept_only:
+            self.match_results.add_good_match(fn)
+            return i_list[0].id, False
+        
+        # Otherwise, add to multiple matches to ask the user later
         self.match_results.add_multiple_match(MultipleMatch(fn, i_list))
         return None, True
 
@@ -515,7 +521,7 @@ class Talker:
                     )
                     continue
 
-            issue_id, multiple_match = self._process_file(fn, args.interactive)
+            issue_id, multiple_match = self._process_file(fn, args.interactive, args.accept_only)
             if issue_id:
                 self._write_issue_md(fn, issue_id)
             elif not multiple_match:

--- a/tests/test_talker.py
+++ b/tests/test_talker.py
@@ -208,13 +208,11 @@ def test_process_file(
 
 
 def test_process_file_with_accept_only(
+    talker: Talker,
     fake_comic: ZipFile,
     test_issue_list: list[BaseIssue],
     mocker: any,
 ) -> None:
-    # Create a talker with accept_only=True
-    talker = Talker("Foo", "Bar", True, True)
-
     # Remove any existing metadata from comic fixture
     ca = Comic(str(fake_comic))
     if ca.has_metadata(MetadataFormat.COMIC_RACK):

--- a/tests/test_talker.py
+++ b/tests/test_talker.py
@@ -214,7 +214,7 @@ def test_process_file_with_accept_only(
 ) -> None:
     # Create a talker with accept_only=True
     talker = Talker("Foo", "Bar", True, True)
-    
+
     # Remove any existing metadata from comic fixture
     ca = Comic(str(fake_comic))
     if ca.has_metadata(MetadataFormat.COMIC_RACK):
@@ -222,7 +222,7 @@ def test_process_file_with_accept_only(
 
     # Mock the call to Metron with a single result
     mocker.patch.object(Session, "issues_list", return_value=[test_issue_list[0]])
-    
+
     # Test with a single match
     id_, multiple = talker._process_file(Path(str(fake_comic)), False, True)
     assert id_ is not None

--- a/tests/test_talker.py
+++ b/tests/test_talker.py
@@ -207,6 +207,30 @@ def test_process_file(
     assert 2471 in id_list  # noqa: PLR2004
 
 
+def test_process_file_with_accept_only(
+    fake_comic: ZipFile,
+    test_issue_list: list[BaseIssue],
+    mocker: any,
+) -> None:
+    # Create a talker with accept_only=True
+    talker = Talker("Foo", "Bar", True, True)
+    
+    # Remove any existing metadata from comic fixture
+    ca = Comic(str(fake_comic))
+    if ca.has_metadata(MetadataFormat.COMIC_RACK):
+        ca.remove_metadata(MetadataFormat.COMIC_RACK)
+
+    # Mock the call to Metron with a single result
+    mocker.patch.object(Session, "issues_list", return_value=[test_issue_list[0]])
+    
+    # Test with a single match
+    id_, multiple = talker._process_file(Path(str(fake_comic)), False, True)
+    assert id_ is not None
+    assert id_ == test_issue_list[0].id
+    assert not multiple
+    assert fake_comic in talker.match_results.good_matches
+
+
 @pytest.mark.skipif(sys.platform in ["win32"], reason="Skip Windows.")
 def test_write_issue_md(
     talker: Talker,


### PR DESCRIPTION
As discussed in #180, if a search results in only a single valid match, even if the cover match doesn't meet the required threshold for an auto-match, if --accept-only is passed, then accept it anyway. This should result in a much smoother (less interactive) import for cases where the filename is already well-matched.
