### PR TITLE
Interpret --id as a series id if more than one file is passed in

### DIFF
--- a/metrontagger/options.py
+++ b/metrontagger/options.py
@@ -42,7 +42,12 @@ def make_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
     )
-    parser.add_argument("--id", help="Identify file for tagging with the Metron Issue Id.")
+    parser.add_argument(
+        "--id",
+        help="Identify file for tagging with the Metron Issue Id, or restrict directory matches to issues from a specific Metron Series Id.",
+        type=int,
+        default=None,
+    )
     parser.add_argument(
         "-d",
         "--delete",

--- a/metrontagger/run.py
+++ b/metrontagger/run.py
@@ -497,15 +497,9 @@ class Runner:
                 self.args.metroninfo,
                 self.args.comicinfo,
             )
-            if self.args.id:
-                if len(file_list) == 1:
-                    t.retrieve_single_issue(self.args.id, file_list[0])
-                else:
-                    questionary.print(
-                        "More than one file was passed for Id processing. Exiting...",
-                        style=Styles.WARNING,
-                    )
-                    sys.exit(0)
+            if self.args.id and len(file_list) == 1:
+                # Single file with --id: interpret as issue ID
+                t.retrieve_single_issue(self.args.id, file_list[0])
             else:
                 t.identify_comics(self.args, file_list)
 

--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mokkari.schemas.generic import GenericItem
-    from mokkari.schemas.issue import BaseIssue, BasicSeries, Credit as MokkariCredit, Issue
+    from mokkari.schemas.issue import BaseIssue, Credit as MokkariCredit, Issue
 
 import mokkari
 import questionary
@@ -258,7 +258,7 @@ class Talker:
         return src, id_
 
     def _process_file(  # noqa: PLR0912 PLR0911 PLR0915
-        self: Talker, fn: Path, accept_only: bool = False, series: BasicSeries | None = None
+        self: Talker, fn: Path, accept_only: bool = False, series_id: int | None = None
     ) -> tuple[int | None, bool]:
         """Process a comic file for metadata.
 
@@ -268,7 +268,7 @@ class Talker:
         Args:
             fn: Path: The file path of the comic to process.
             accept_only: bool: A flag indicating if the process should automatically accept a match if it's the only one.
-            series: BasicSeries | None: Optional series to restrict matches to only issues from that series.
+            series_id: int | None: Optional series ID to restrict matches to only issues from that series.
         Returns: tuple[int | None, bool]: A tuple containing the issue ID and a flag indicating if multiple matches
         were found.
         """
@@ -341,6 +341,8 @@ class Talker:
         # Alright, if the comic doesn't have an let's do a search based on the filename.
         # TODO: Determine if we want to use some of the other keys beyond 'series' and 'issue number'
         metadata: dict[str, str | tuple[str, ...]] = comicfn2dict(fn, verbose=0)
+        if series_id is not None:
+            metadata["series_id"] = series_id
 
         params = create_query_params(metadata)
         if params is None:
@@ -349,19 +351,6 @@ class Talker:
             )
             return None, False
         i_list = self.api.issues_list(params=params)
-        # Filter by series_id if provided
-        if series is not None:
-            i_list = [
-                issue
-                for issue in i_list
-                if issue.series.name == series.name
-                and issue.series.year_began == series.year_began
-            ]
-            if not i_list:
-                questionary.print(
-                    f"'{fn.name}' matched issues, but none from series {series}",
-                    style=Styles.WARNING,
-                )
         result_count = len(i_list)
 
         # No matches
@@ -507,10 +496,6 @@ class Talker:
             None
         """
         if args.id is not None:
-            series = self.api.series(args.id)
-            if series is None:
-                questionary.print(f"Series ID {args.id} not found", style=Styles.ERROR)
-                return
             msg = create_print_title(
                 f"Starting Online Search and Tagging (Series ID: {args.id}):"
             )
@@ -536,7 +521,9 @@ class Talker:
                     )
                     continue
 
-            issue_id, multiple_match = self._process_file(fn, args.accept_only, series=series)
+            issue_id, multiple_match = self._process_file(
+                fn, args.accept_only, series_id=args.id
+            )
             if issue_id:
                 self._write_issue_md(fn, issue_id)
             elif not multiple_match:

--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -83,26 +83,34 @@ def create_query_params(metadata: dict[str, str | tuple[str, ...]]) -> dict[str,
     Returns:
         dict[str, str]: The query parameters for searching.
     """
-    # Remove hyphen when searching for series name
-    try:
-        series_string: str = (
-            metadata["series"].replace(" - ", " ").replace(",", "").replace(" & ", " ").strip()
-        )
-    except KeyError:
-        LOGGER.error("Bad filename parsing: %s", metadata)  # NOQA: TRY400
-        return None
+    params = {}
+
+    if "series_id" in metadata:
+        params["series_id"] = metadata["series_id"]
+    else:
+        # Remove hyphen when searching for series name
+        try:
+            params["series_name"] = (
+                metadata["series"]
+                .replace(" - ", " ")
+                .replace(",", "")
+                .replace(" & ", " ")
+                .strip()
+            )
+        except KeyError:
+            LOGGER.error("Bad filename parsing: %s", metadata)  # NOQA: TRY400
+            return None
 
     # If there isn't an issue number, let's assume it's "1".
-    number: str = quote_plus(metadata["issue"].encode("utf-8")) if "issue" in metadata else "1"
+    params["number"] = (
+        quote_plus(metadata["issue"].encode("utf-8")) if "issue" in metadata else "1"
+    )
 
     # Strip any leading zeros from the issue number for the API to correctly match.
-    number = number.lstrip("0")
+    params["number"] = params["number"].lstrip("0")
 
     # Handle issues with #½
-    if number == ".5":
-        number = "½"
+    if params["number"] == ".5":
+        params["number"] = "½"
 
-    return {
-        "series_name": series_string,
-        "number": number,
-    }
+    return params

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -53,7 +53,7 @@ from metrontagger.options import make_parser
                 "online": True,
                 "metroninfo": True,
                 "comicinfo": True,
-                "id": "12345",
+                "id": 12345,
                 "delete": True,
                 "ignore_existing": True,
                 "missing": True,


### PR DESCRIPTION
Change the behaviour of `--id` when more than one file is passed in (after resolving recursively, filtering, etc).

Currently, `--id` fails if more than one file is passed in, because it's interpreted as an issue ID and it obviously
doesn't make sense to tag multiple files with the same issue. But now it is assumed that if you're passing in --id
with multiple files, you intend for `--id` to represent a series id rather than an issue id. All files being passed
in are assumed to belong to that series, and all results from the metron API are filtered down to ones that match
that series.

Originally I used the existing call to /issues but then I realized I can just pass the series_id to /issues directly
and avoid an extra call to fetch series metadata. So now it all works server-side without the need for any extra
calls.

All tests pass, lint is checked, and manual testing indicates success:

```bash
$ poetry run metron-tagger -oc --accept-only --id 1857 /Volumes/tank1/media/text/Comics/Komga/Comics/Tales\ of\ Suspense\ \(1959\) 

Starting Online Search and Tagging (Series ID: 1857):
-----------------------------------------------------
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #1 (1959)' for 'Tales of Suspense 001.cbz'.
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #2 (1959)' for 'Tales of Suspense 002.cbz'.
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #3 (1959)' for 'Tales of Suspense 003.cbz'.
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #4 (1959)' for 'Tales of Suspense 004.cbz'.
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #5 (1959)' for 'Tales of Suspense 005.cbz'.
Writing 'ComicInfo.xml' metadata using 'Tales of Suspense #6 (1959)' for 'Tales of Suspense 006.cbz'.

Successful Matches:
-------------------
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 001.cbz
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 002.cbz
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 003.cbz
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 004.cbz
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 005.cbz
/Volumes/tank1/media/text/Comics/Komga/Comics/Tales of Suspense (1959)/Tales of Suspense 006.cbz
```

(Previously to this, issue 001 would match both Tales of Suspense (1959) and (1995) for some reason).